### PR TITLE
Fix:cable.yml

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -5,6 +5,7 @@ test:
   adapter: test
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: selfserch_production
+  #adapter: redis
+  #url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  #channel_prefix: selfserch_production
+  adapter: async


### PR DESCRIPTION
概要
-ネットの記事にてherokuでactioncableがローカルと同じように動かない理由ははcable.ymlがproductionと違うからだという。
 そこで同じように修正。