### PR TITLE
Fix:image-url(/enviroment/backgroud.jpg);

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -8,11 +8,6 @@ section {
 }
 
 .white-text {color: rgb(250, 248, 246);}
-body {
-    background-image: image-url('enviroment/backgroud.jpg');
-    background-size: cover;
-    background-position: center;
-}
 
 .blue-text {color: #0CB4EC;}
 


### PR DESCRIPTION
概要
herokuにpushでエラーが出た。
       yarn run v1.22.19
       $ sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules
       Done in 2.79s.
       rake aborted!
       SassC::SyntaxError: Error: Invalid CSS after "...oment/backgroud": expected expression (e.g. 1px, bold), was ".jpg);"
               on line 34933:52 of stdin
       >> und-image: image-url(/enviroment/backgroud.jpg);